### PR TITLE
Removing characters from line one that prevent npm from working

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
-git add -{
+{
   "name": "github-practice-2",
   "version": "1.0.0",
   "description": "Project 2 Starter",


### PR DESCRIPTION
I was unable to run 'npm i' on our project template as is. Looks like "git add -" was on the first line just before the JSON. Removed those characters to try to fix. 